### PR TITLE
Update supported docker image OS for aws-workertools

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -41,99 +41,99 @@ jobs:
         }      
       shell: powershell
 
-  build-linux:
+  build-ubuntu:
     needs: [get-version-number]
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3    
     
-    - name: Dockerhub Login
+    - name: DockerHub Login
       env:
         USERNAME: ${{ secrets.DOCKER_HUB_USER }}
         PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
       run: docker login --username $USERNAME --password "$PASSWORD"
     
-    - name: Build the Docker image 
-      env:
-        VERSION_NUMBER: ${{ needs.get-version-number.outputs.VERSION }}     
-      run: docker build ./ubuntu-1804 --tag octopuslabs/aws-workertools:$VERSION_NUMBER-ubuntu.1804 --tag octopuslabs/aws-workertools:latest-ubuntu.1804
-      if: ${{ needs.get-version-number.outputs.CONTINUE == 'Yes' }}
-      
-    - name: Push the version image
-      env:
-        VERSION_NUMBER: ${{ needs.get-version-number.outputs.VERSION }}     
-      run: docker push octopuslabs/aws-workertools:$VERSION_NUMBER-ubuntu.1804
-      if: ${{ needs.get-version-number.outputs.CONTINUE == 'Yes' }}
-      
-    - name: Push the latest image
-      env:
-        VERSION_NUMBER: ${{ needs.get-version-number.outputs.VERSION }}     
-      run: docker push octopuslabs/aws-workertools:latest-ubuntu.1804
-      if: ${{ needs.get-version-number.outputs.CONTINUE == 'Yes' }}
-
-    - name: Build the Docker image      
+    - name: Build the ubuntu-20.04 Docker image 
       env:
         VERSION_NUMBER: ${{ needs.get-version-number.outputs.VERSION }}     
       run: docker build ./ubuntu-2004 --tag octopuslabs/aws-workertools:$VERSION_NUMBER-ubuntu.2004 --tag octopuslabs/aws-workertools:latest-ubuntu.2004
       if: ${{ needs.get-version-number.outputs.CONTINUE == 'Yes' }}
       
-    - name: Push the version image
+    - name: Push the ubuntu-20.04 version image
       env:
         VERSION_NUMBER: ${{ needs.get-version-number.outputs.VERSION }}     
       run: docker push octopuslabs/aws-workertools:$VERSION_NUMBER-ubuntu.2004
       if: ${{ needs.get-version-number.outputs.CONTINUE == 'Yes' }}
       
-    - name: Push the latest image
+    - name: Push the latest ubuntu-20.04 image
       env:
         VERSION_NUMBER: ${{ needs.get-version-number.outputs.VERSION }}     
       run: docker push octopuslabs/aws-workertools:latest-ubuntu.2004
       if: ${{ needs.get-version-number.outputs.CONTINUE == 'Yes' }}
+
+    - name: Build the ubuntu-22.04 Docker image      
+      env:
+        VERSION_NUMBER: ${{ needs.get-version-number.outputs.VERSION }}     
+      run: docker build ./ubuntu-2204 --tag octopuslabs/aws-workertools:$VERSION_NUMBER-ubuntu.2204 --tag octopuslabs/aws-workertools:latest-ubuntu.2204
+      if: ${{ needs.get-version-number.outputs.CONTINUE == 'Yes' }}
       
-  build-windows-2019:
+    - name: Push the ubuntu-22.04 version image
+      env:
+        VERSION_NUMBER: ${{ needs.get-version-number.outputs.VERSION }}     
+      run: docker push octopuslabs/aws-workertools:$VERSION_NUMBER-ubuntu.2204
+      if: ${{ needs.get-version-number.outputs.CONTINUE == 'Yes' }}
+      
+    - name: Push the latest ubuntu-22.04 image
+      env:
+        VERSION_NUMBER: ${{ needs.get-version-number.outputs.VERSION }}     
+      run: docker push octopuslabs/aws-workertools:latest-ubuntu.2204
+      if: ${{ needs.get-version-number.outputs.CONTINUE == 'Yes' }}
+      
+  build-win-2019:
     needs: [get-version-number]
     runs-on: windows-2019
 
     steps:
     - uses: actions/checkout@v3
         
-    - name: Dockerhub Login
+    - name: DockerHub Login
       env:
         USERNAME: ${{ secrets.DOCKER_HUB_USER }}
         PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
       run: docker login --username ${env:USERNAME} --password "${env:PASSWORD}"
     
-    - name: Build the Docker image
+    - name: Build the win2019 Docker image
       env:
         VERSION_NUMBER: ${{ needs.get-version-number.outputs.VERSION }}     
       run: docker build ./windows-2019 --tag octopuslabs/aws-workertools:${env:VERSION_NUMBER}-windows.2019 --tag octopuslabs/aws-workertools:latest-windows.2019
       if: ${{ needs.get-version-number.outputs.CONTINUE == 'Yes' }}
       
-    - name: Push the version image
+    - name: Push the win2019 version image
       env:
         VERSION_NUMBER: ${{ needs.get-version-number.outputs.VERSION }}     
       run: docker push octopuslabs/aws-workertools:${env:VERSION_NUMBER}-windows.2019
       if: ${{ needs.get-version-number.outputs.CONTINUE == 'Yes' }}
       
-    - name: Push the latest image
+    - name: Push the latest win2019 image
       env:
         VERSION_NUMBER: ${{ needs.get-version-number.outputs.VERSION }}     
       run: docker push octopuslabs/aws-workertools:latest-windows.2019
       if: ${{ needs.get-version-number.outputs.CONTINUE == 'Yes' }}
   
   build-docker-manifest:
-    needs: [build-windows-2019, build-linux, get-version-number]
+    needs: [get-version-number, build-ubuntu, build-win-2019]
     runs-on: ubuntu-latest
     
     steps:
-    - name: Dockerhub Login
+    - name: DockerHub Login
       env:
         USERNAME: ${{ secrets.DOCKER_HUB_USER }}
         PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
       run: docker login --username $USERNAME --password "$PASSWORD"
       
     - name: Build Manifest
-      run: docker manifest create octopuslabs/aws-workertools:latest octopuslabs/aws-workertools:latest-windows.2019 octopuslabs/aws-workertools:latest-ubuntu.1804
+      run: docker manifest create octopuslabs/aws-workertools:latest octopuslabs/aws-workertools:latest-windows.2019 octopuslabs/aws-workertools:latest-ubuntu.2004
       if: ${{ needs.get-version-number.outputs.CONTINUE == 'Yes' }}
       
     - name: Push Manifest
@@ -143,7 +143,7 @@ jobs:
     - name: Build Version Manifest
       env:
         VERSION_NUMBER: ${{ needs.get-version-number.outputs.VERSION }}     
-      run: docker manifest create octopuslabs/aws-workertools:$VERSION_NUMBER octopuslabs/aws-workertools:$VERSION_NUMBER-windows.2019 octopuslabs/aws-workertools:$VERSION_NUMBER-ubuntu.1804
+      run: docker manifest create octopuslabs/aws-workertools:$VERSION_NUMBER octopuslabs/aws-workertools:$VERSION_NUMBER-windows.2019 octopuslabs/aws-workertools:$VERSION_NUMBER-ubuntu.2004
       if: ${{ needs.get-version-number.outputs.CONTINUE == 'Yes' }}
       
     - name: Push Version Manifest

--- a/README.md
+++ b/README.md
@@ -4,15 +4,16 @@ This repository contains images that contain the tooling necessary to to use the
 
 - AWS CLI
 - AWS ECS
+- AWS EKS CTL
 - TerraForm
 - AWS PowerShell Tools Common
 
-There are three images built in this repo:
+The following images are built in this repo:
 
-- Ubuntu 20.04
-- Ubuntu 18.04
-- Windows 2019
+- Ubuntu 22.04
+- Ubuntu 20.04 (tagged `latest` in [DockerHub](https://hub.docker.com/r/octopuslabs/aws-workertools/tags?page=1&name=latest))
+- Windows 2019 (tagged `latest` in [DockerHub](https://hub.docker.com/r/octopuslabs/aws-workertools/tags?page=1&name=latest))
 
 A new image will be built each time a new version of AWS CLI is created.  The version numbers will be based on the version of AWS CLI.
 
-**Please Consider this repository provided as is.  If there are any issues please do not contact support.**
+**Please consider this repository provided as is.  If there are any issues please do not contact support.**

--- a/ubuntu-2004/Dockerfile
+++ b/ubuntu-2004/Dockerfile
@@ -2,9 +2,9 @@ FROM octopuslabs/workertools:latest-ubuntu.2004
 
 # Get Terraform
 # https://developer.hashicorp.com/terraform/downloads
-RUN wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor | sudo tee /usr/share/keyrings/hashicorp-archive-keyring.gpg && \
-    echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list && \
-    sudo apt update && sudo apt install terraform
+RUN wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor | tee /usr/share/keyrings/hashicorp-archive-keyring.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/hashicorp.list && \
+    apt update && apt install terraform
 
 # Get AWS CLI
 # https://docs.aws.amazon.com/cli/latest/userguide/install-linux.html#install-linux-awscli

--- a/ubuntu-2004/Dockerfile
+++ b/ubuntu-2004/Dockerfile
@@ -4,7 +4,7 @@ FROM octopuslabs/workertools:latest-ubuntu.2004
 # https://developer.hashicorp.com/terraform/downloads
 RUN wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor | tee /usr/share/keyrings/hashicorp-archive-keyring.gpg && \
     echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/hashicorp.list && \
-    apt update && apt install terraform
+    apt update && apt install -y terraform
 
 # Get AWS CLI
 # https://docs.aws.amazon.com/cli/latest/userguide/install-linux.html#install-linux-awscli

--- a/ubuntu-2004/Dockerfile
+++ b/ubuntu-2004/Dockerfile
@@ -1,10 +1,10 @@
 FROM octopuslabs/workertools:latest-ubuntu.2004
 
 # Get Terraform
-# https://computingforgeeks.com/how-to-install-terraform-on-ubuntu-centos-7/
-RUN curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add - && \
-    apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main" && \
-    apt-get update && apt-get install terraform -y
+# https://developer.hashicorp.com/terraform/downloads
+RUN wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor | sudo tee /usr/share/keyrings/hashicorp-archive-keyring.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list && \
+    sudo apt update && sudo apt install terraform
 
 # Get AWS CLI
 # https://docs.aws.amazon.com/cli/latest/userguide/install-linux.html#install-linux-awscli

--- a/ubuntu-2204/Dockerfile
+++ b/ubuntu-2204/Dockerfile
@@ -4,7 +4,7 @@ FROM octopuslabs/workertools:latest-ubuntu.2204
 # https://developer.hashicorp.com/terraform/downloads
 RUN wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor | tee /usr/share/keyrings/hashicorp-archive-keyring.gpg && \
     echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/hashicorp.list && \
-    apt update && apt install terraform
+    apt update && apt install -y terraform
 
 # Get AWS CLI
 # https://docs.aws.amazon.com/cli/latest/userguide/install-linux.html#install-linux-awscli

--- a/ubuntu-2204/Dockerfile
+++ b/ubuntu-2204/Dockerfile
@@ -1,10 +1,10 @@
-FROM octopuslabs/workertools:latest-ubuntu.1804
+FROM octopuslabs/workertools:latest-ubuntu.2204
 
 # Get Terraform
-# https://computingforgeeks.com/how-to-install-terraform-on-ubuntu-centos-7/
-RUN curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add - && \
-    apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main" && \
-    apt-get update && apt-get install terraform -y
+# https://developer.hashicorp.com/terraform/downloads
+RUN wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor | sudo tee /usr/share/keyrings/hashicorp-archive-keyring.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list && \
+    sudo apt update && sudo apt install terraform
 
 # Get AWS CLI
 # https://docs.aws.amazon.com/cli/latest/userguide/install-linux.html#install-linux-awscli

--- a/ubuntu-2204/Dockerfile
+++ b/ubuntu-2204/Dockerfile
@@ -2,9 +2,9 @@ FROM octopuslabs/workertools:latest-ubuntu.2204
 
 # Get Terraform
 # https://developer.hashicorp.com/terraform/downloads
-RUN wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor | sudo tee /usr/share/keyrings/hashicorp-archive-keyring.gpg && \
-    echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list && \
-    sudo apt update && sudo apt install terraform
+RUN wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor | tee /usr/share/keyrings/hashicorp-archive-keyring.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/hashicorp.list && \
+    apt update && apt install terraform
 
 # Get AWS CLI
 # https://docs.aws.amazon.com/cli/latest/userguide/install-linux.html#install-linux-awscli

--- a/windows-2019/Dockerfile
+++ b/windows-2019/Dockerfile
@@ -6,14 +6,14 @@ SHELL ["powershell", "-Command"]
 # Install Terraform
 RUN choco install terraform -y --no-progress
 
-# # Install AWS CLI
+# Install AWS CLI
 RUN choco install awscli -y --no-progress
 
-# # Install ECS CLI
+# Install ECS CLI
 RUN choco install ecs-cli -y --no-progress; `
     refreshenv
 
-# # Install eksctl
+# Install eksctl
 RUN choco install eksctl -y --no-progress; `
     refreshenv
 


### PR DESCRIPTION
Removes Ubuntu 18.04, adds Ubuntu 22.04, and makes 20.04 the latest